### PR TITLE
fix parseList

### DIFF
--- a/.theme/footer.html
+++ b/.theme/footer.html
@@ -128,7 +128,7 @@ return a+c}}),Jb?module.exports=tb:"function"==typeof define&&define.amd?(define
                 var type,
                     $this = $(this),
                     $img = $this.find("img");
-                if ($img.length) {
+                if ($img.length && $img.attr("alt").length) {
                     type = $img.attr("alt").replace(/\[/g, '').replace(/\]/g, '');
                     $this.addClass("type--" + type);
                 }


### PR DESCRIPTION
parseList causes a JS error on rows without image:

```
Uncaught TypeError: Cannot read property 'replace' of undefined
```
